### PR TITLE
Preserve the structure of the deploy directory in copy

### DIFF
--- a/tasks/wp-plugin.js
+++ b/tasks/wp-plugin.js
@@ -103,7 +103,7 @@ module.exports = function( grunt ) {
 					del(['**'], { cwd: svnTrunkDir }, function( err ) {
 						grunt.log.warn( 'Plug-in trunk deleted.' );
 
-						cpy(['**'], svnTrunkDir, { cwd: deployDir }, function( err ) {
+						cpy(['**'], svnTrunkDir, { cwd: deployDir, parents: true }, function( err ) {
 							grunt.log.ok( 'Plug-in from deploy -> trunk copied.' );
 
 							if ( grunt.file.isDir( assetsDir ) ) {


### PR DESCRIPTION
If the plugin you want to deploy, has additional folders the `cpy` function (from the deploy directory to the trunk), currently does not preserve the folder structure.

According to the [cpy](https://github.com/sindresorhus/cpy#parents) docs, you can preserve the structure just by adding this option.
